### PR TITLE
Add upperCaseFruits assertions, expand array literal matching

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,8 +23,8 @@ var noForLoops = function(func) {
 
 var noNewArrays = function(func) {
   var stringified = func.toString();
-  it('should not create new arrays', function() {
-    expect(stringified.includes(('[]' || '[ ]'))).to.equal(false);
+  it('should not create new array literals', function() {
+    expect(stringified).not.to.match(/\[\s+\]/);
   });
 }
 

--- a/spec.js
+++ b/spec.js
@@ -346,6 +346,13 @@
             var data = upperCaseFruits(testFruits);
             expect(data).to.not.eql(testFruits);
           });
+          it('should return an array of strings', function () {
+            var data = upperCaseFruits(testFruits);
+            expect(Array.isArray(data), 'returned value should be an array').to.be.true;
+            _.each(data, function (fruit) {
+              expect(fruit).to.be.a('string');
+            });
+          });
           it('should return an array with all strings converted to uppercase', function () {
             var data = upperCaseFruits(testFruits);
             var allUpperCase = true;


### PR DESCRIPTION
This PR adds an assertion to the `upperCaseFruits` prompt to ensure:
- it returns an array
- the array contains strings
This resolves the issues where the tests for this prompt pass even if nothing is returned, or nothing is returned from the mapping function (which would cause an error when the function does return an array, but it's not super readable for students)

Also modifies the array literal test to use regex whitespace matching, so that arbitrary amounts of whitespace (including newlines) are also included.